### PR TITLE
Use 50,000 as the base for remediation points

### DIFF
--- a/codeclimate-gofmt.go
+++ b/codeclimate-gofmt.go
@@ -50,7 +50,7 @@ func main() {
 					Type:              "issue",
 					Check:             "GoFmt/Style/GoFmt",
 					Description:       "Your code does not pass gofmt in " + numHunks + " places. Go fmt your code!",
-					RemediationPoints: int32(500 * len(diffs[0].Hunks)),
+					RemediationPoints: int32(50000 * len(diffs[0].Hunks)),
 					Categories:        []string{"Style"},
 					Location: &engine.Location{
 						Path: path,


### PR DESCRIPTION
500 is _much_ too low. Spec says 50,000 is appropriate for trivial issues like missing semicolons, so it seems like an appropriate baseline here.

This change is a bit different from the other 2 go engines I've updated, since this one isn't a constant value, but adjusts based on how different `gofmt`'s change is from the existing code. I still think this is reasonable as a baseline based on the spec's language: if a 1 character "difference" like a missing semicolon is worth 50,000 points, then counting each "hunk" here as worth that much seems reasonable.
