### PR TITLE
Bump golang version to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=1.13.1-alpine3.10
+ARG BASE=1.18-alpine3.14
 FROM golang:${BASE} as build
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN export go_version=$(go version | cut -d ' ' -f 3) && \
     cat engine.json.template | jq '.version = .version + "/" + env.go_version' > ./engine.json
 
 COPY codeclimate-gofmt.go ./
+COPY go.mod go.sum ./
 RUN apk add --no-cache git
 RUN go get -t -d -v .
 RUN go build -o codeclimate-gofmt .

--- a/codeclimate-gofmt.go
+++ b/codeclimate-gofmt.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"github.com/codeclimate/cc-engine-go/engine"
-	"sourcegraph.com/sourcegraph/go-diff/diff"
+	"github.com/sourcegraph/go-diff/diff"
+	"os"
 	"os/exec"
 	"strconv"
-	"os"
 	"strings"
-	"fmt"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/codeclimate-community/codeclimate-gofmt
+
+go 1.18
+
+require (
+	github.com/codeclimate/cc-engine-go v0.0.0-20160217183426-55f9c825e2a9
+	github.com/sourcegraph/go-diff v0.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/codeclimate/cc-engine-go v0.0.0-20160217183426-55f9c825e2a9 h1:Wk8UDfEjmZtZI8guLovZZ1QXkbGIPWy2cpeYS2JgKPg=
+github.com/codeclimate/cc-engine-go v0.0.0-20160217183426-55f9c825e2a9/go.mod h1:A0vs4JxevyA0WJrMjU/5sedZBlICgsdPloAKENM2JmU=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
+github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
+github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
+github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Bumps golang version to 1.18 to allow support for generics syntax.
Current maintainability checks will fail due to invalid syntax.