### PR TITLE
QUA-753: Update gofmt to use go 1.20.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=1.18-alpine3.14
+ARG BASE=1.20.2-alpine3.17
 FROM golang:${BASE} as build
 
 WORKDIR /usr/src/app

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeclimate-community/codeclimate-gofmt
 
-go 1.18
+go 1.20
 
 require (
 	github.com/codeclimate/cc-engine-go v0.0.0-20160217183426-55f9c825e2a9
-	github.com/sourcegraph/go-diff v0.6.1
+	github.com/sourcegraph/go-diff v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,4 +6,6 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
+github.com/sourcegraph/go-diff v0.7.0 h1:9uLlrd5T46OXs5qpp8L/MTltk0zikUGi0sNNyCpA8G0=
+github.com/sourcegraph/go-diff v0.7.0/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This PR updates golang to version 1.20.2 to support gofmt's latest version